### PR TITLE
Add float support.

### DIFF
--- a/src/com/roscopeco/ormdroid/NumericTypeMapping.java
+++ b/src/com/roscopeco/ormdroid/NumericTypeMapping.java
@@ -55,7 +55,11 @@ public class NumericTypeMapping implements TypeMapping {
     if (expectedType.equals(Boolean.class) || expectedType.equals(boolean.class)) {
       int i = c.getInt(columnIndex);
       return (i == 0) ? false : true;
-    } else {
+    }
+    else if (expectedType.equals(Float.class) || expectedType.equals(float.class)) {
+      return c.getFloat(columnIndex);
+    }
+    else {
       return c.getInt(columnIndex);
     }
   }


### PR DESCRIPTION
I see that other types such as shorts are in TypeMapper.java but not in NumericTypeMapping.java, was there an issue here?  This at least does make floats work correctly.
