### PR TITLE
Update Query.generate() to prevent data mix

### DIFF
--- a/src/com/roscopeco/ormdroid/Query.java
+++ b/src/com/roscopeco/ormdroid/Query.java
@@ -232,7 +232,7 @@ public class Query<T extends Entity> {
   }
 
   private String generate(int limit) {    
-    StringBuilder sb = new StringBuilder().append("SELECT * FROM ").append(mEntityMapping.mTableName);
+    StringBuilder sb = new StringBuilder().append("SELECT ").append(mEntityMapping.mTableName).append(".* FROM ").append(mEntityMapping.mTableName);
     
     if (customSql != null) {
       return sb.append(" ").append(customSql).toString();


### PR DESCRIPTION
`SELECT sometable.* FROM sometable` is now the base `Entity.query(...)` SQL Query
